### PR TITLE
fix: skipword union

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -65,6 +65,12 @@ export class TypeUtil {
     idType: ts.Type,
     skipClass: boolean,
   ): false | "skip" | { property: string; objectName: string } => {
+    // skipword
+    const idTypeName = idType.aliasSymbol?.name ?? idType.symbol?.name ?? false;
+    if (idTypeName && this.skipWords.includes(idTypeName)) {
+      return false;
+    }
+
     // Check if initType is a Union
     if (initType.isUnion()) {
       const result = initType.types.map((type) =>
@@ -117,12 +123,6 @@ export class TypeUtil {
       idType.flags <= 2048
     ) {
       return "skip";
-    }
-
-    // skipword
-    const idTypeName = idType.aliasSymbol?.name ?? idType.symbol?.name ?? false;
-    if (idTypeName && this.skipWords.includes(idTypeName)) {
-      return false;
     }
 
     // circular structure

--- a/tests/no-excess-property.skip-word.test.ts
+++ b/tests/no-excess-property.skip-word.test.ts
@@ -62,6 +62,16 @@ ruleTester.run("no-excess-property", rule, {
       `,
       options: [{ skipWords: ["Blob"] }],
     },
+    {
+      code: `
+      type Human = { name: string };
+      type Robot = { age: number };
+      type User = Human | Robot;
+      const jiro = { name: "jiro", age: 10 };
+      const sampleUser: User = jiro;
+      `,
+      options: [{ skipWords: ["User"] }],
+    },
   ],
   invalid: [
     {


### PR DESCRIPTION
```ts
type Human = { name: string };
type Robot = { age: number };
type User = Human | Robot;
const jiro = { name: "jiro", age: 10 };
const sampleUser: User = jiro; // ok
```