### PR TITLE
add: class check option

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,11 @@ Add the following to your ESLint configuration file (such as .eslintrc):
   "rules": {
     "no-excess-property/no-excess-property": [
       "error",
-      { "skipWords": ["UncheckedTypeName"], "checkJsx": true }
+      {
+        "skipWords": ["UncheckedTypeName"],
+        "checkJsx": true,
+        "checkClass": false
+      }
     ]
   },
   "parser": "@typescript-eslint/parser",
@@ -49,6 +53,16 @@ const dummyUsers2: User[] = [...Array(10)].map((_, idx) => ({
   name: `${idx}`,
   age: idx,
 })); // Error
+```
+
+### JSX
+
+```tsx
+type Props = { name: string };
+const Component = (props: Props) => <div>{props.name}</div>;
+const user = { name: "Taro", age: 20 };
+const appOk = <Component name={user.name} />; // OK
+const appError = <Component {...user} />; // Error
 ```
 
 ### Function
@@ -85,34 +99,20 @@ const func3: Func = (user) => {
 };
 ```
 
-## Exceptions
-
-### Class
-
-```ts
-class BaseUser {
-  name: string;
-}
-class ExtendedUser extends BaseUser {
-  age: number;
-}
-const user: BaseUser = new ExtendedUser(); // OK
-```
-
 ## Setting
 
 ```json
 "rules": {
   "no-excess-property/no-excess-property": [
     "error",
-    { "skipWords": ["UserElement"], "checkJsx": true }
+    { "skipWords": ["UserElement"], "checkJsx": true, "checkClass": false }
   ]
 },
 ```
 
 ### skipWords
 
-Types registered in “skipwords” are not inspected.
+Types registered in `skipWords` are not inspected.
 
 ```ts
 type UserElement = { name: string };
@@ -123,6 +123,20 @@ const element: UserElement = taro; // OK
 ### checkJsx
 
 If `false`, the rule does not check JSX attributes. default is `true`.
+
+### checkClass
+
+If `false`, the rule does not check class properties. default is `false`.
+
+```ts
+class BaseUser {
+  name: string;
+}
+class ExtendedUser extends BaseUser {
+  age: number;
+}
+const user: BaseUser = new ExtendedUser(); // OK
+```
 
 ## License
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   preset: "ts-jest",
-  testMatch: ["**/tests/**/*.ts", "**/tests/**/*.tsx",],
+  testMatch: ["**/tests/**/*.ts", "**/tests/**/*.tsx"],
   transform: {
     "^.+\\.[tj]sx?$": [
       "ts-jest",

--- a/src/no-excess-property.ts
+++ b/src/no-excess-property.ts
@@ -14,7 +14,13 @@ export = createRule({
     if (!checker || !parserServices) return {};
     const skipWords = context.options[0]?.skipWords ?? [];
     const checkJsx = context.options[0]?.checkJsx ?? true;
-    const typeUtil = new TypeUtil(checker, parserServices, skipWords);
+    const checkClass = context.options[0]?.checkClass ?? false;
+    const typeUtil = new TypeUtil(
+      checker,
+      parserServices,
+      skipWords,
+      checkClass,
+    );
 
     const checkReturnStatement = (
       returnStatements: TSESTree.ReturnStatement[],
@@ -29,11 +35,8 @@ export = createRule({
         if (
           returnTypes.every(
             (type) =>
-              typeof typeUtil.checkProperties(
-                returnStatementNode,
-                type,
-                true,
-              ) === "object",
+              typeof typeUtil.checkProperties(returnStatementNode, type) ===
+              "object",
           )
         ) {
           context.report({
@@ -108,7 +111,7 @@ export = createRule({
                     idNode,
                     tsNode,
                   );
-                  return typeUtil.checkProperties(initType, idType, true);
+                  return typeUtil.checkProperties(initType, idType);
                 },
               );
               return checkResult.some((e) => typeof e === "object")
@@ -151,7 +154,7 @@ export = createRule({
           const result = tsSignatures
             .map((sigType) => {
               const tsType = sigType.getTypeParameterAtPosition(idx);
-              return typeUtil.checkProperties(argType, tsType, true);
+              return typeUtil.checkProperties(argType, tsType);
             })
             .filter((e) => e !== "skip");
 
@@ -195,11 +198,8 @@ export = createRule({
             if (
               returnTypes.every(
                 (type) =>
-                  typeof typeUtil.checkProperties(
-                    returnStatementNode,
-                    type,
-                    true,
-                  ) === "object",
+                  typeof typeUtil.checkProperties(returnStatementNode, type) ===
+                  "object",
               )
             ) {
               context.report({
@@ -226,11 +226,7 @@ export = createRule({
           parserServices.esTreeNodeToTSNodeMap.get(node.id),
         );
 
-        const excessPropertyData = typeUtil.checkProperties(
-          initType,
-          idType,
-          true,
-        );
+        const excessPropertyData = typeUtil.checkProperties(initType, idType);
         if (typeof excessPropertyData === "object") {
           context.report({
             node,
@@ -267,11 +263,16 @@ export = createRule({
           checkJsx: {
             type: "boolean",
           },
+          checkClass: {
+            type: "boolean",
+          },
         },
         additionalProperties: false,
       },
     ],
   },
   name: "no-excess-property",
-  defaultOptions: [{ skipWords: [] as string[], checkJsx: true }],
+  defaultOptions: [
+    { skipWords: [] as string[], checkJsx: true, checkClass: false },
+  ],
 });

--- a/tests/no-excess-property.class.test.ts
+++ b/tests/no-excess-property.class.test.ts
@@ -9,6 +9,12 @@ const ruleTester = new TSESLint.RuleTester({
   },
 });
 
+const errors = [
+  {
+    messageId: "no-excess-property",
+  },
+] as const;
+
 ruleTester.run("no-excess-property", rule, {
   valid: [
     {
@@ -19,7 +25,7 @@ ruleTester.run("no-excess-property", rule, {
       class Hoge extends Fuga {
         piyo() {}
       }
-      const fuga = new Hoge();
+      const fuga: Fuga = new Hoge();
       `,
     },
     {
@@ -47,6 +53,75 @@ ruleTester.run("no-excess-property", rule, {
       func(buhi);
       `,
     },
+    {
+      code: `
+      class Fuga {
+        fuga() {}
+      }
+      class Hoge extends Fuga {
+        private hoge() {}
+      }
+      const fuga: Fuga = new Hoge();
+      `,
+      options: [{ checkClass: true, checkJsx: false, skipWords: [] }],
+    },
   ],
-  invalid: [],
+  invalid: [
+    {
+      code: `
+      class Fuga {
+        fuga() {}
+      }
+      class Hoge extends Fuga {
+        piyo() {}
+      }
+      const fuga: Fuga = new Hoge();
+      `,
+      errors,
+      options: [{ checkClass: true, checkJsx: false, skipWords: [] }],
+    },
+    {
+      code: `
+      class Hoge {
+        fuga() {}
+        piyo() {}
+      }
+      const hoge = new Hoge();
+      const func = (d: {fuga: ()=>void}) => {};
+      func(hoge);
+      `,
+      errors,
+      options: [{ checkClass: true, checkJsx: false, skipWords: [] }],
+    },
+    {
+      code: `
+      class Hoge {
+        fuga() {}
+        piyo() {}
+      }
+      class Buhi {
+        hoge = new Hoge();
+      }
+      const buhi = new Buhi();
+      const func = (buhi:{hoge:{fuga:()=>void}}) => {};
+      func(buhi);
+      `,
+      errors,
+      options: [{ checkClass: true, checkJsx: false, skipWords: [] }],
+    },
+    {
+      code: `
+      class Fuga {
+        fuga() {}
+      }
+      class Hoge extends Fuga {
+        private hoge() {}
+        piyo() {}
+      }
+      const fuga: Fuga = new Hoge();
+      `,
+      errors,
+      options: [{ checkClass: true, checkJsx: false, skipWords: [] }],
+    },
+  ],
 });

--- a/tests/no-excess-property.class.test.ts
+++ b/tests/no-excess-property.class.test.ts
@@ -65,6 +65,19 @@ ruleTester.run("no-excess-property", rule, {
       `,
       options: [{ checkClass: true, checkJsx: false, skipWords: [] }],
     },
+    {
+      code: `
+      class Fuga {
+        fuga() {}
+      }
+      class Hoge extends Fuga {
+        private hoge = 10;
+        private piyo() {}
+      }
+      const fuga: Fuga = new Hoge();
+      `,
+      options: [{ checkClass: true, checkJsx: false, skipWords: [] }],
+    },
   ],
   invalid: [
     {
@@ -117,6 +130,20 @@ ruleTester.run("no-excess-property", rule, {
       class Hoge extends Fuga {
         private hoge() {}
         piyo() {}
+      }
+      const fuga: Fuga = new Hoge();
+      `,
+      errors,
+      options: [{ checkClass: true, checkJsx: false, skipWords: [] }],
+    },
+    {
+      code: `
+      class Fuga {
+        fuga() {}
+      }
+      class Hoge extends Fuga {
+        hoge = 10;
+        private piyo() {}
       }
       const fuga: Fuga = new Hoge();
       `,

--- a/tests/no-excess-property.index-type.test.ts
+++ b/tests/no-excess-property.index-type.test.ts
@@ -59,14 +59,20 @@ ruleTester.run("no-excess-property", rule, {
       const sampleUser: Record<string, User> = { taro };
       `,
     },
-
     {
       code: `
-      type User = { name: string };
       const taro = { name: "taro" };
       const sampleUser: [key: string] = { taro };
       `,
     },
+    // todo: fix it
+    // {
+    //   code: `
+    //   type User = { [propertyName: \`data-\${string}\`]: string };
+    //   const taro = { "data-name": "taro" };
+    //   const sampleUser: User = taro;
+    //   `,
+    // },
   ],
   invalid: [
     {

--- a/tests/no-excess-property.intersept.test.ts
+++ b/tests/no-excess-property.intersept.test.ts
@@ -1,0 +1,38 @@
+import { TSESLint } from "@typescript-eslint/utils";
+import rule from "../src/no-excess-property";
+
+const ruleTester = new TSESLint.RuleTester({
+  parser: require.resolve("@typescript-eslint/parser"),
+  parserOptions: {
+    sourceType: "module",
+    project: "./tsconfig.test.json",
+  },
+});
+
+const errors = [
+  {
+    messageId: "no-excess-property",
+  },
+] as const;
+
+ruleTester.run("no-excess-property", rule, {
+  valid: [
+    {
+      code: `
+      type User = { name: string } & { age: number };
+      const taro = { name: "taro", age: 10 };
+      const sampleUser: User = taro;
+      `,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+      type User = { name: string } & { age: number };
+      const taro = { name: "taro", age: 10, tel: "123-4567-8901" };
+      const sampleUser: User = taro;
+      `,
+      errors,
+    },
+  ],
+});

--- a/tests/no-excess-property.jsx.test.tsx
+++ b/tests/no-excess-property.jsx.test.tsx
@@ -107,7 +107,7 @@ ruleTester.run("no-excess-property", rule, {
       const user = { name: "taro", age: 10 };
       const app = <Components data={user} />;
       `,
-      options: [{ skipWords: [], checkJsx: false }],
+      options: [{ skipWords: [], checkJsx: false, checkClass: false }],
     },
     // todo: fix this
     // {
@@ -159,6 +159,17 @@ ruleTester.run("no-excess-property", rule, {
       };
       const user = { name: "taro", age: 10 };
       const app = <Components data={user} isHuman />;
+      `,
+      errors,
+    },
+    {
+      code: `
+      type Props =
+        | ({ name: string } & { age: number })
+        | ({ name: string } & { id: string });
+      const Component = (props: Props) => <div>{props.name}</div>;
+      const user = { name: "Taro", age: 20, id: "user_id" };
+      <Component {...user} />;
       `,
       errors,
     },

--- a/tests/no-excess-property.skip-word.test.ts
+++ b/tests/no-excess-property.skip-word.test.ts
@@ -29,7 +29,7 @@ ruleTester.run("no-excess-property", rule, {
       const jiro = { name: "jiro", age: 10 };
       const sampleUser: User = jiro;
       `,
-      options: [{ skipWords: ["User"], checkJsx: false }],
+      options: [{ skipWords: ["User"], checkJsx: false, checkClass: false }],
     },
     {
       code: `
@@ -38,7 +38,7 @@ ruleTester.run("no-excess-property", rule, {
       const createUser = (user: User) => {};
       createUser(jiro);
       `,
-      options: [{ skipWords: ["User"], checkJsx: false }],
+      options: [{ skipWords: ["User"], checkJsx: false, checkClass: false }],
     },
     {
       code: `
@@ -46,13 +46,13 @@ ruleTester.run("no-excess-property", rule, {
         return file;
       };
       `,
-      options: [{ skipWords: ["Blob"], checkJsx: false }],
+      options: [{ skipWords: ["Blob"], checkJsx: false, checkClass: false }],
     },
     {
       code: `
       const func = (file: File): Blob => file;
       `,
-      options: [{ skipWords: ["Blob"], checkJsx: false }],
+      options: [{ skipWords: ["Blob"], checkJsx: false, checkClass: false }],
     },
     {
       code: `
@@ -60,7 +60,7 @@ ruleTester.run("no-excess-property", rule, {
         return file;
       };
       `,
-      options: [{ skipWords: ["Blob"], checkJsx: false }],
+      options: [{ skipWords: ["Blob"], checkJsx: false, checkClass: false }],
     },
     {
       code: `
@@ -70,7 +70,7 @@ ruleTester.run("no-excess-property", rule, {
       const jiro = { name: "jiro", age: 10 };
       const sampleUser: User = jiro;
       `,
-      options: [{ skipWords: ["User"], checkJsx: false }],
+      options: [{ skipWords: ["User"], checkJsx: false, checkClass: false }],
     },
   ],
   invalid: [
@@ -80,7 +80,7 @@ ruleTester.run("no-excess-property", rule, {
       const jiro = { name: "jiro", age: 10 };
       const sampleUser: User = jiro;
       `,
-      options: [{ skipWords: ["user"], checkJsx: false }],
+      options: [{ skipWords: ["user"], checkJsx: false, checkClass: false }],
       errors,
     },
     {
@@ -90,7 +90,9 @@ ruleTester.run("no-excess-property", rule, {
       const createUser = (user: User) => {};
       createUser(jiro);
       `,
-      options: [{ skipWords: ["HogeType"], checkJsx: false }],
+      options: [
+        { skipWords: ["HogeType"], checkJsx: false, checkClass: false },
+      ],
       errors,
     },
     {
@@ -99,14 +101,14 @@ ruleTester.run("no-excess-property", rule, {
         return file;
       };
       `,
-      options: [{ skipWords: ["File"], checkJsx: false }],
+      options: [{ skipWords: ["File"], checkJsx: false, checkClass: false }],
       errors: funcErrors,
     },
     {
       code: `
       const func = (file: File): Blob => file;
       `,
-      options: [{ skipWords: ["File"], checkJsx: false }],
+      options: [{ skipWords: ["File"], checkJsx: false, checkClass: false }],
       errors: funcErrors,
     },
     {
@@ -115,7 +117,7 @@ ruleTester.run("no-excess-property", rule, {
         return file;
       };
       `,
-      options: [{ skipWords: ["File"], checkJsx: false }],
+      options: [{ skipWords: ["File"], checkJsx: false, checkClass: false }],
       errors: funcErrors,
     },
   ],


### PR DESCRIPTION
オプション `checkClass` が trueのとき、classの余剰プロパティチェックを行う。ただし、privateは無視する

```ts
class Fuga {
  fuga() {}
}
class Hoge extends Fuga {
  private hoge() {}
}
const fuga: Fuga = new Hoge(); // OK
```

```ts
class Fuga {
  fuga() {}
}
class Hoge extends Fuga {
  private hoge() {}
  piyo() {}
}
const fuga: Fuga = new Hoge(); // Error
```
