### PR TITLE
fix: skip jsx key attr

### DIFF
--- a/src/no-excess-property.ts
+++ b/src/no-excess-property.ts
@@ -132,7 +132,8 @@ export = createRule({
 
               const checkResult = Object.entries(allProps).map(
                 ([key, initType]) => {
-                  if (skipProperties.includes(key)) return false;
+                  if (skipProperties.includes(key) || key === "key")
+                    return false;
                   const idNode = idTypeProperties.find((e) => e.name === key);
                   if (!idNode) return { property: key, objectName: "" };
                   const idType = checker.getTypeOfSymbolAtLocation(

--- a/tests/no-excess-property.jsx.test.tsx
+++ b/tests/no-excess-property.jsx.test.tsx
@@ -101,6 +101,14 @@ ruleTester.run("no-excess-property", rule, {
     },
     {
       code: `
+      function Components(props: { name: string }) {
+        return <div>{props.name}</div>;
+      }
+      const app = <Components name="taro" key={1} />;
+      `,
+    },
+    {
+      code: `
       type Props = {[K in \`data-\${string}\`]: string } & { age: number }
       const Component = (props: Props) => {
         return <div>{}</div>;


### PR DESCRIPTION
```tsx
function Components(props: { name: string }) {
  return <div>{props.name}</div>;
}
const app = <Components name="taro" key={1} />; // ok
```