### PR TITLE
fix: refactor type flags

### DIFF
--- a/tests/no-excess-property.union-type-init.test.ts
+++ b/tests/no-excess-property.union-type-init.test.ts
@@ -68,6 +68,42 @@ ruleTester.run("no-excess-property", rule, {
     },
     {
       code: `
+      // union * union: string -> obj, string -> obj
+      type User = string | { name: string };
+      const taro = { name: "taro" } as string | { name: string, tel: string };
+      const user: User = taro;
+      `,
+      errors,
+    },
+    {
+      code: `
+      // union * union: string -> obj, obj -> string
+      type User = string | { name: string };
+      const taro = { name: "taro" } as { name: string, tel: string } | string;
+      const user: User = taro;
+      `,
+      errors,
+    },
+    {
+      code: `
+      // union * union: obj -> string, string -> obj
+      type User = { name: string } | string;
+      const taro = { name: "taro" } as string | { name: string, tel: string };
+      const user: User = taro;
+      `,
+      errors,
+    },
+    {
+      code: `
+      // union * union: obj -> string, obj -> string
+      type User = { name: string } | string;
+      const taro = { name: "taro" } as { name: string, tel: string } | string;
+      const user: User = taro;
+      `,
+      errors,
+    },
+    {
+      code: `
       type TypeA = { name: string, tel?: string };
       type TypeB = { name: string, age: number };
       type TypeC = { name: string };


### PR DESCRIPTION
use logical conjunction (AND) 

```ts 
if (
  !!(idType.flags & ID_ALLOW_TYPE_FLAG) ||
  !!(initType.flags & INIT_ALLOW_TYPE_FLAG)
) {
  return false;
}
if (!!(idType.flags & ID_SKIP_FLAG)) {
  return "skip";
}
```